### PR TITLE
[Fix] Remove html based on editor id.

### DIFF
--- a/web_ckeditor4/static/src/js/web_ckeditor4.js
+++ b/web_ckeditor4/static/src/js/web_ckeditor4.js
@@ -204,10 +204,11 @@ odoo.define('web_ckeditor4', function(require){
         {
             if(this.editor)
             {
+                var id = this.editor.id
                 this.editor.removeAllListeners();
                 this.editor.destroy();
                 this.editor = null;
-                $('#cke_results').remove()
+                $('.' + id).remove()
             }
         },
         destroy: function()


### PR DESCRIPTION
The HTML ids which are generated by CK contain the field name, so they aren't useful for the removal of the Editor. The internal Editor id is added as a class on the html and does the job correctly. 
/cc @simahawk