### PR TITLE
`web_ckeditor4` fix switch to translations

### DIFF
--- a/web_ckeditor4/static/src/js/web_ckeditor4.js
+++ b/web_ckeditor4/static/src/js/web_ckeditor4.js
@@ -208,13 +208,13 @@ odoo.define('web_ckeditor4', function(require){
                 this.editor.removeAllListeners();
                 this.editor.destroy();
                 this.editor = null;
-                $('.' + id).remove()
+                $('.' + id).remove();
             }
         },
         destroy: function()
         {
-            this.destroy_content();
-            this._super();
+          this._cleanup_editor();
+          this._super();
         },
         destroy_content: function()
         {

--- a/web_ckeditor4/static/src/js/web_ckeditor4_formview.js
+++ b/web_ckeditor4/static/src/js/web_ckeditor4_formview.js
@@ -1,0 +1,23 @@
+odoo.define('web_ckeditor4.FormView', function(require) {
+  "use strict";
+
+  var core = require('web.core');
+  var FormView = core.view_registry.get('form');
+
+  FormView.include({
+
+    can_be_discarded: function(message) {
+      var self = this;
+      var res = this._super().done(function() {
+        // if form can be discarded
+        // we want to destroy all ck4 editor instances
+        for(name in CKEDITOR.instances){
+          self.fields[name].destroy_content();
+        }
+      });
+      return res;
+    }
+
+  });
+
+});

--- a/web_ckeditor4/views/qweb.xml
+++ b/web_ckeditor4/views/qweb.xml
@@ -11,6 +11,8 @@
                 <script type="text/javascript"
                         src="/web_ckeditor4/static/lib/ckeditor/config.js"></script>
                 <script type="text/javascript"
+                        src="/web_ckeditor4/static/src/js/web_ckeditor4_formview.js"></script>
+                <script type="text/javascript"
                         src="/web_ckeditor4/static/src/js/web_ckeditor4.js"></script>
             </xpath>
         </template>


### PR DESCRIPTION
Behavior before this commit:

* go to a form where you have the editor enabled
* click on edit
* click on ANY translate icon
  (not necessarily the on of the field w/ ck4 editor widget)
* click "yes I want to go away from the form"
* get to the translation page
* click on the breadcrumb/path menu to get back to the record -> KABOOM!

JS is broken because the editor was not destroyed.

Here we patch form view discard hook
as it seems the only place where something happens
when we click on 'translate', whereas we still have the form in our hands.